### PR TITLE
fixed some compiler errors under gcc and clang

### DIFF
--- a/include/std23/__functional_base.h
+++ b/include/std23/__functional_base.h
@@ -41,23 +41,23 @@ inline constexpr auto _select_param_type = []
 };
 
 template<class T>
-using _param_t = std::invoke_result_t<decltype(_select_param_type<T>)>::type;
+using _param_t = typename std::invoke_result_t<decltype(_select_param_type<T>)>::type;
 
 template<class T, class Self>
 inline constexpr bool _is_not_self =
     not std::is_same_v<std::remove_cvref_t<T>, Self>;
 
-template<class T, template<class> class>
+template<class T, template<class...> class>
 inline constexpr bool _looks_nullable_to_impl = std::is_member_pointer_v<T>;
 
-template<class F, template<class> class Self>
+template<class F, template<class...> class Self>
 inline constexpr bool _looks_nullable_to_impl<F *, Self> =
     std::is_function_v<F>;
 
 template<class... S, template<class...> class Self>
 inline constexpr bool _looks_nullable_to_impl<Self<S...>, Self> = true;
 
-template<class S, template<class> class Self>
+template<class S, template<class...> class Self>
 inline constexpr bool _looks_nullable_to =
     _looks_nullable_to_impl<std::remove_cvref_t<S>, Self>;
 
@@ -72,7 +72,7 @@ struct _adapt_signature<F *>
     using type = F;
 };
 
-template<class Fp> using _adapt_signature_t = _adapt_signature<Fp>::type;
+template<class Fp> using _adapt_signature_t = typename _adapt_signature<Fp>::type;
 
 template<class S> struct _not_qualifying_this
 {};
@@ -220,7 +220,7 @@ struct _drop_first_arg_to_invoke<M G::*, T> : _not_qualifying_this<M>
 {};
 
 template<class F, class T>
-using _drop_first_arg_to_invoke_t = _drop_first_arg_to_invoke<F, T>::type;
+using _drop_first_arg_to_invoke_t = typename _drop_first_arg_to_invoke<F, T>::type;
 
 } // namespace std23
 

--- a/include/std23/function.h
+++ b/include/std23/function.h
@@ -22,7 +22,7 @@ template<class R, class... Args> struct _opt_fn_sig<R(Args...)>
         std::is_invocable_r_v<R, T..., Args...>;
 };
 
-template<class R, class... Args> struct _opt_fn_sig<R(Args......)>
+template<class R, class... Args> struct _opt_fn_sig<R(Args..., ...)>
 {
     using function_type = R(Args...);
     static constexpr bool is_variadic = true;
@@ -206,8 +206,8 @@ template<class S, class R, class... Args> class function<S, R(Args...)>
                            _copyable_function<R, _param_t<Args>..., va_list &>,
                            _copyable_function<R, _param_t<Args>...>>;
 
-    using lvalue_callable = copyable_function::lvalue_callable;
-    using empty_target_object = copyable_function::empty_target_object;
+    using lvalue_callable = typename copyable_function::lvalue_callable;
+    using empty_target_object = typename copyable_function::empty_target_object;
 
     struct typical_target_object : lvalue_callable
     {
@@ -220,15 +220,15 @@ template<class S, class R, class... Args> class function<S, R(Args...)>
 
     template<class F>
     using target_object_for =
-        copyable_function::template target_object<std::unwrap_ref_decay_t<F>>;
+        typename copyable_function::template target_object<std::unwrap_ref_decay_t<F>>;
 
     template<auto f>
     using unbound_target_object =
-        copyable_function::template unbound_target_object<f>;
+        typename copyable_function::template unbound_target_object<f>;
 
     template<auto f, class T>
     using bound_target_object_for =
-        copyable_function::template bound_target_object<
+        typename copyable_function::template bound_target_object<
             f, std::unwrap_ref_decay_t<T>>;
 
     template<class F, class FD = std::decay_t<F>>
@@ -344,7 +344,7 @@ template<class S, class R, class... Args> class function<S, R(Args...)>
 #pragma GCC diagnostic ignored "-Wunused-value"
 #endif
 
-    R operator()(Args... args...) const
+    R operator()(Args... args, ...) const
         requires(signature::is_variadic and sizeof...(Args) != 0)
     {
         struct raii
@@ -373,7 +373,7 @@ template<class R, class... Args> struct _strip_noexcept<R(Args...) noexcept>
     using type = R(Args...);
 };
 
-template<class S> using _strip_noexcept_t = _strip_noexcept<S>::type;
+template<class S> using _strip_noexcept_t = typename _strip_noexcept<S>::type;
 
 template<class F> requires std::is_function_v<F>
 function(F *) -> function<_strip_noexcept_t<F>>;

--- a/include/std23/function_ref.h
+++ b/include/std23/function_ref.h
@@ -91,7 +91,7 @@ class function_ref<Sig, R(Args...)> // freestanding
 {
     using signature = _qual_fn_sig<Sig>;
 
-    template<class T> using cv = signature::template cv<T>;
+    template<class T> using cv = typename signature::template cv<T>;
     template<class T> using cvref = cv<T> &;
     static constexpr bool noex = signature::is_noexcept;
 

--- a/include/std23/move_only_function.h
+++ b/include/std23/move_only_function.h
@@ -348,7 +348,6 @@ struct _move_only_function_base : _move_only_function_base_base<S, R, Args...>
 {
     using base = _move_only_function_base_base<S, R, Args...>;
 
-    using typename base::signature;
     template<class T> using cv = typename base::template cv<T>;
     template<class T> using ref = typename base::template ref<T>;
 
@@ -356,9 +355,6 @@ struct _move_only_function_base : _move_only_function_base_base<S, R, Args...>
     using base::is_const;
     using base::is_lvalue_only;
     using base::is_rvalue_only;
-
-    using base::vtbl_;
-    using base::obj_;
 
     using typename base::trait;
 
@@ -420,7 +416,6 @@ struct _move_only_function_base<S, R, Args...> : _move_only_function_base_base<S
 {
     using base = _move_only_function_base_base<S, R, Args...>;
 
-    using typename base::signature;
     template<class T> using cv = typename base::template cv<T>;
     template<class T> using ref = typename base::template ref<T>;
 
@@ -454,9 +449,7 @@ template<class S, class R, class... Args>
 class move_only_function<S, R(Args...)> : _move_only_function_base<S, R, Args...>
 {
     using base = _move_only_function_base<S, R, Args...>;
-    friend base;
 
-    using typename base::signature;
     template<class T> using cv = typename base::template cv<T>;
     template<class T> using ref = typename base::template ref<T>;
 
@@ -624,8 +617,6 @@ class move_only_function<S, R(Args...)> : _move_only_function_base<S, R, Args...
     }
 
     using base::operator();
-
-  private:
 };
 
 } // namespace std23


### PR DESCRIPTION
Fixed a number of compiler errors that occurred when com piling under Linux. Tested were g++-12 and clang++-14 under Debian Bookworm.