### PR TITLE
feat: support Clang

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-2022, ubuntu-20.04 ]
+        os: [ windows-2022, ubuntu-20.04, macos-15 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The implementation does not guarantee the best performance under all use cases b
 | -------------------- | ---------------- | ------------------ |
 | GCC >= 11.1.0        | libstdc++        | Ubuntu 20.04       |
 | MSVC >= 14.30        | Microsoft STL    | Visual Studio 2022 |
+| Clang >= 17.0.6      | libc++           | Xcode 16.0         |
 
 
 ## Installation

--- a/include/std23/__functional_base.h
+++ b/include/std23/__functional_base.h
@@ -47,17 +47,17 @@ template<class T, class Self>
 inline constexpr bool _is_not_self =
     not std::is_same_v<std::remove_cvref_t<T>, Self>;
 
-template<class T, template<class> class>
+template<class T, template<class...> class>
 inline constexpr bool _looks_nullable_to_impl = std::is_member_pointer_v<T>;
 
-template<class F, template<class> class Self>
+template<class F, template<class...> class Self>
 inline constexpr bool _looks_nullable_to_impl<F *, Self> =
     std::is_function_v<F>;
 
 template<class... S, template<class...> class Self>
 inline constexpr bool _looks_nullable_to_impl<Self<S...>, Self> = true;
 
-template<class S, template<class> class Self>
+template<class S, template<class...> class Self>
 inline constexpr bool _looks_nullable_to =
     _looks_nullable_to_impl<std::remove_cvref_t<S>, Self>;
 

--- a/include/std23/function.h
+++ b/include/std23/function.h
@@ -314,7 +314,7 @@ template<class S, class R, class... Args> class function<S, R(Args...)>
     explicit operator bool() const noexcept
     {
         constexpr empty_target_object null;
-        return __builtin_memcmp(storage_, &null, sizeof(void *)) != 0;
+        return __builtin_memcmp(storage_, (void *)&null, sizeof(void *)) != 0;
     }
 
     friend bool operator==(function const &f, nullptr_t) noexcept { return !f; }

--- a/tests/function/test_ctad.cpp
+++ b/tests/function/test_ctad.cpp
@@ -7,13 +7,14 @@ inline constexpr bool deduction_enabled = type_traits::is_valid<T>(
 void test_ctad()
 {
     {
-        function fn = [i = 0] { return 0; };
+        function fn = [i = 0] { return i; };
         static_assert(std::is_same_v<decltype(fn), function<int()>>);
         static_assert(std::is_same_v<decltype(fn)::result_type, int>);
     }
 
     {
-        function fn = [i = 0](int &&, int const) mutable { return "lit"; };
+        function fn = [i = 0](int &&, int const) mutable
+        { return (void)i, "lit"; };
         static_assert(
             std::is_same_v<decltype(fn), function<char const *(int &&, int)>>);
         static_assert(std::is_same_v<decltype(fn)::result_type, char const *>);
@@ -27,7 +28,7 @@ void test_ctad()
     }
 
     {
-        function fn = [i = 0]() noexcept { return 0; };
+        function fn = [i = 0]() noexcept { return i; };
         static_assert(std::is_same_v<decltype(fn), function<int()>>,
                       "[func.wrap.func.con]/16");
         static_assert(std::is_same_v<decltype(fn)::result_type, int>);

--- a/tests/function_ref/test_call_pattern.cpp
+++ b/tests/function_ref/test_call_pattern.cpp
@@ -67,7 +67,7 @@ suite call_pattern = []
             {
                 expect(fr() == some_str);
 
-                auto fn = [i = 0] { return some_str.data(); };
+                auto fn = [i = 0] { return (void)i, some_str.data(); };
                 fr = decltype(fr)(fn);
 
                 expect(fr() == some_str);

--- a/tests/move_only_function/CMakeLists.txt
+++ b/tests/move_only_function/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(run-move_only_function PRIVATE
  "test_unique.cpp"
 )
 target_compile_options(run-move_only_function PRIVATE
-    $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-self-move>
+    $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-self-move>
     $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-fsized-deallocation>)
 target_link_libraries(run-move_only_function PRIVATE nontype_functional kris-ut)
 set_target_properties(run-move_only_function PROPERTIES OUTPUT_NAME run)

--- a/tests/move_only_function/CMakeLists.txt
+++ b/tests/move_only_function/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(run-move_only_function PRIVATE
  "test_unique.cpp"
 )
 target_compile_options(run-move_only_function PRIVATE
+    $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-self-move>
     $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-fsized-deallocation>)
 target_link_libraries(run-move_only_function PRIVATE nontype_functional kris-ut)
 set_target_properties(run-move_only_function PROPERTIES OUTPUT_NAME run)


### PR DESCRIPTION
Clang has implemented all C++20 features that this project uses except P0522. However, since the resolution of P3310 leans towards requiring variadic form on at least the main template (implemented in Clang 19), we should just back off the requirement.

Tested with AppleClang 16.0.0 (Xcode 16) on macOS 15, ARM64 architecture.

See also: [P3310R4 _Solving issues introduced by P0522R0_](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3310r4.html)
